### PR TITLE
Fix #14: implement is_resolved update for CSP violations

### DIFF
--- a/_dev/.env.example
+++ b/_dev/.env.example
@@ -24,3 +24,8 @@ COMPOSE_PROJECT_NAME=ps81
 
 # URL of the PrestaShop instance (used by Playwright e2e tests)
 WEBSITE_URL=http://localhost:8090
+
+# Admin credentials and path (used by Playwright e2e tests for admin panel)
+ADMIN_EMAIL=demo@prestashop.com
+ADMIN_PASSWORD=prestashop_demo
+ADMIN_PATH=/admin

--- a/_dev/docker-compose.yml
+++ b/_dev/docker-compose.yml
@@ -73,6 +73,9 @@ services:
       - ../tests/functionnal:/tests
     environment:
       - WEBSITE_URL=http://localhost:${PS_PORT:-8090}
+      - ADMIN_EMAIL=${ADMIN_EMAIL:-demo@prestashop.com}
+      - ADMIN_PASSWORD=${ADMIN_PASSWORD:-prestashop_demo}
+      - ADMIN_PATH=${ADMIN_PATH:-/admin}
       - CI=true
     profiles:
       - testing

--- a/classes/CspViolation.php
+++ b/classes/CspViolation.php
@@ -177,6 +177,33 @@ class CspViolation extends ObjectModel
     }
 
     /**
+     * Mark this violation as resolved
+     *
+     * @return bool
+     */
+    public function markAsResolved(): bool
+    {
+        $this->is_resolved = true;
+        $this->date_upd = date('Y-m-d H:i:s');
+
+        return $this->update();
+    }
+
+    /**
+     * Mark all unresolved violations as resolved
+     *
+     * @return bool
+     */
+    public static function markAllAsResolved(): bool
+    {
+        return Db::getInstance()->execute(
+            'UPDATE `' . _DB_PREFIX_ . 'hhcspheaders_violations`
+             SET `is_resolved` = 1, `date_upd` = NOW()
+             WHERE `is_resolved` = 0'
+        );
+    }
+
+    /**
      * Get violations statistics
      *
      * @return array

--- a/hhcspheaders.php
+++ b/hhcspheaders.php
@@ -578,9 +578,27 @@ class Hhcspheaders extends Module
             return $this->displayConfirmation($this->l('Settings updated'));
         }
 
-        if (Tools::getValue('clear_violations')) {
-            require_once _PS_MODULE_DIR_ . 'hhcspheaders/classes/CspViolation.php';
+        require_once _PS_MODULE_DIR_ . 'hhcspheaders/classes/CspViolation.php';
 
+        if (Tools::getValue('resolve_violation')) {
+            $idViolation = (int) Tools::getValue('resolve_violation');
+            $violation = new CspViolation($idViolation);
+            if (Validate::isLoadedObject($violation) && $violation->markAsResolved()) {
+                return $this->displayConfirmation($this->l('Violation marked as resolved'));
+            } else {
+                return $this->displayError($this->l('Unable to mark violation as resolved'));
+            }
+        }
+
+        if (Tools::getValue('resolve_all_violations')) {
+            if (CspViolation::markAllAsResolved()) {
+                return $this->displayConfirmation($this->l('All violations marked as resolved'));
+            } else {
+                return $this->displayError($this->l('Unable to mark violations as resolved'));
+            }
+        }
+
+        if (Tools::getValue('clear_violations')) {
             if ($this->clearResolvedViolations()) {
                 return $this->displayConfirmation($this->l('Resolved violations cleared successfully'));
             } else {
@@ -718,12 +736,18 @@ class Hhcspheaders extends Module
             return '<div class="alert alert-success">' . $this->l('No violations detected yet.') . '</div>';
         }
 
-        $clearLink = $this->context->link->getAdminLink('AdminModules', false)
+        $baseLink = $this->context->link->getAdminLink('AdminModules', false)
             . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name
-            . '&token=' . Tools::getAdminTokenLite('AdminModules') . '&clear_violations=1';
+            . '&token=' . Tools::getAdminTokenLite('AdminModules');
+        $clearLink = $baseLink . '&clear_violations=1';
+        $resolveAllLink = $baseLink . '&resolve_all_violations=1';
 
         $html = '<p class="alert alert-info">';
         $html .= $this->l('Showing the 20 most recent unresolved violations.');
+        $html .= ' <a href="' . $resolveAllLink . '" class="btn btn-sm btn-success" onclick="return confirm(\''
+            . $this->l('Are you sure you want to mark all violations as resolved?') . '\');">';
+        $html .= '<i class="icon-check"></i> ' . $this->l('Mark all as resolved');
+        $html .= '</a>';
         $html .= ' <a href="' . $clearLink . '" class="btn btn-sm btn-danger" onclick="return confirm(\''
             . $this->l('Are you sure you want to clear all resolved violations?') . '\');">';
         $html .= '<i class="icon-trash"></i> ' . $this->l('Clear Resolved Violations');
@@ -739,11 +763,13 @@ class Hhcspheaders extends Module
         $html .= '<th>' . $this->l('Document URI') . '</th>';
         $html .= '<th>' . $this->l('Occurrences') . '</th>';
         $html .= '<th>' . $this->l('Last Seen') . '</th>';
+        $html .= '<th>' . $this->l('Action') . '</th>';
         $html .= '</tr>';
         $html .= '</thead>';
         $html .= '<tbody>';
 
         foreach ($violations as $violation) {
+            $resolveLink = $baseLink . '&resolve_violation=' . (int) $violation['id_violation'];
             $html .= '<tr>';
             $html .= '<td><code>' . htmlspecialchars($violation['violated_directive']) . '</code></td>';
             $html .= '<td style="word-break: break-all; max-width: 250px;">'
@@ -752,6 +778,8 @@ class Hhcspheaders extends Module
                 . htmlspecialchars($violation['document_uri']) . '</td>';
             $html .= '<td><span class="badge badge-warning">' . (int) $violation['occurrences'] . '</span></td>';
             $html .= '<td>' . htmlspecialchars($violation['last_seen']) . '</td>';
+            $html .= '<td><a href="' . $resolveLink . '" class="btn btn-xs btn-success">'
+                . '<i class="icon-check"></i> ' . $this->l('Resolve') . '</a></td>';
             $html .= '</tr>';
         }
 

--- a/tests/Unit/CspViolationTest.php
+++ b/tests/Unit/CspViolationTest.php
@@ -145,4 +145,44 @@ class CspViolationTest extends TestCase
         $this->assertGreaterThanOrEqual($before, $violation->date_upd);
         $this->assertLessThanOrEqual($after, $violation->date_upd);
     }
+
+    public function testMarkAsResolvedSetsIsResolvedToTrue(): void
+    {
+        $violation = new CspViolation();
+        $violation->is_resolved = false;
+
+        $violation->markAsResolved();
+
+        $this->assertTrue($violation->is_resolved);
+    }
+
+    public function testMarkAsResolvedUpdatesDateUpd(): void
+    {
+        $violation = new CspViolation();
+        $violation->date_upd = '2020-01-01 00:00:00';
+
+        $before = date('Y-m-d H:i:s');
+        $violation->markAsResolved();
+        $after = date('Y-m-d H:i:s');
+
+        $this->assertGreaterThanOrEqual($before, $violation->date_upd);
+        $this->assertLessThanOrEqual($after, $violation->date_upd);
+    }
+
+    public function testMarkAsResolvedReturnsTrue(): void
+    {
+        $violation = new CspViolation();
+
+        $result = $violation->markAsResolved();
+
+        $this->assertTrue($result);
+    }
+
+    public function testMarkAllAsResolvedReturnsBool(): void
+    {
+        $result = CspViolation::markAllAsResolved();
+
+        $this->assertIsBool($result);
+        $this->assertTrue($result);
+    }
 }

--- a/tests/functionnal/e2e/pages/violationsAdminPage.ts
+++ b/tests/functionnal/e2e/pages/violationsAdminPage.ts
@@ -1,0 +1,65 @@
+import {expect, Page} from '@playwright/test';
+
+export class ViolationsAdminPage {
+    private readonly page: Page;
+    private readonly adminEmail: string;
+    private readonly adminPassword: string;
+    private readonly fixtureUrl: string;
+
+    private readonly adminPath: string;
+
+    public constructor(page: Page, moduleName: string) {
+        this.page = page;
+        this.adminEmail = process.env.ADMIN_EMAIL ?? 'demo@prestashop.com';
+        this.adminPassword = process.env.ADMIN_PASSWORD ?? 'prestashop_demo';
+        this.adminPath = process.env.ADMIN_PATH ?? '/admin';
+        this.fixtureUrl = `modules/${moduleName}/tests/functionnal/manage_violations.php`;
+    }
+
+    public async setupViolations(): Promise<void> {
+        await this.page.goto(this.fixtureUrl + '?action=setup');
+        await expect(this.page.locator('.warning')).toHaveCount(0);
+    }
+
+    public async cleanupViolations(): Promise<void> {
+        await this.page.goto(this.fixtureUrl + '?action=cleanup');
+    }
+
+    public async loginToAdmin(): Promise<void> {
+        await this.page.goto(this.adminPath);
+        await this.page.fill('#email', this.adminEmail);
+        await this.page.fill('#passwd', this.adminPassword);
+        await this.page.click('#submit_login');
+        await this.page.waitForURL(new RegExp(this.adminPath));
+    }
+
+    public async navigateToModuleConfig(): Promise<void> {
+        const token = await this.page.evaluate((): string => {
+            const link = document.querySelector('a[href*="_token="]');
+            if (!link) return '';
+            const m = link.getAttribute('href')!.match(/_token=([^&]+)/);
+            return m ? m[1] : '';
+        });
+        await this.page.goto(
+            `${this.adminPath}/improve/modules/manage/action/configure/hhcspheaders?_token=${token}`
+        );
+        await this.activateLogsTab();
+    }
+
+    public async activateLogsTab(): Promise<void> {
+        await this.page.locator('a[href="#logs"]').click();
+        await this.page.locator('#logs').waitFor({state: 'visible'});
+    }
+
+    public getViolationRows() {
+        return this.page.locator('table.table tbody tr');
+    }
+
+    public getResolveButton(index: number) {
+        return this.getViolationRows().nth(index).locator('a.btn-success');
+    }
+
+    public getMarkAllButton() {
+        return this.page.locator('a.btn-success[href*="resolve_all_violations"]');
+    }
+}

--- a/tests/functionnal/e2e/violations-admin.spec.ts
+++ b/tests/functionnal/e2e/violations-admin.spec.ts
@@ -1,0 +1,45 @@
+import {test, expect} from '@playwright/test';
+import {ViolationsAdminPage} from './pages/violationsAdminPage';
+
+test.describe.configure({mode: 'serial'});
+const moduleName = 'hhcspheaders';
+
+test.describe('CHECK VIOLATIONS RESOLUTION', () => {
+
+    test.afterAll(async ({browser}) => {
+        const ctx = await browser.newContext();
+        const page = await ctx.newPage();
+        const vp = new ViolationsAdminPage(page, moduleName);
+        await vp.cleanupViolations();
+        await ctx.close();
+    });
+
+    test('RESOLVE_SINGLE_VIOLATION', async ({page}) => {
+        const vp = new ViolationsAdminPage(page, moduleName);
+        await vp.setupViolations();
+        await vp.loginToAdmin();
+        await vp.navigateToModuleConfig();
+
+        await expect(vp.getViolationRows()).toHaveCount(2);
+
+        await vp.getResolveButton(0).click();
+        await vp.activateLogsTab();
+
+        await expect(vp.getViolationRows()).toHaveCount(1);
+    });
+
+    test('RESOLVE_ALL_VIOLATIONS', async ({page}) => {
+        const vp = new ViolationsAdminPage(page, moduleName);
+        await vp.setupViolations();
+        await vp.loginToAdmin();
+        await vp.navigateToModuleConfig();
+
+        page.once('dialog', dialog => dialog.accept());
+        await vp.getMarkAllButton().click();
+        await vp.activateLogsTab();
+
+        await expect(
+            page.locator('div.alert-success').filter({hasText: 'No violations detected'})
+        ).toBeVisible();
+    });
+});

--- a/tests/functionnal/manage_violations.php
+++ b/tests/functionnal/manage_violations.php
@@ -1,0 +1,23 @@
+<?php
+
+require_once __DIR__ . '/../../../../config/config.inc.php';
+
+$action = strip_tags($_GET['action'] ?? '');
+$now = date('Y-m-d H:i:s');
+
+if ($action === 'setup') {
+    Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'hhcspheaders_violations`');
+    Db::getInstance()->execute(
+        'INSERT INTO `' . _DB_PREFIX_ . 'hhcspheaders_violations`
+         (document_uri, blocked_uri, violated_directive, occurrences, first_seen, last_seen, is_resolved, date_add, date_upd)
+         VALUES
+         ("https://example.com/", "https://evil.com/script.js", "script-src", 3, "' . $now . '", "' . $now . '", 0, "' . $now . '", "' . $now . '"),
+         ("https://example.com/page2", "https://evil.com/style.css", "style-src", 1, "' . $now . '", "' . $now . '", 0, "' . $now . '", "' . $now . '")'
+    );
+    echo 'OK: 2 violations created';
+} elseif ($action === 'cleanup') {
+    Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'hhcspheaders_violations`');
+    echo 'OK: violations cleared';
+} else {
+    echo '<div class="warning">Unknown action: ' . htmlspecialchars($action) . '</div>';
+}

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -84,5 +84,34 @@ class Configuration
     }
 }
 
+class Db
+{
+    private static ?self $instance = null;
+
+    public static function getInstance(): self
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    public function execute(string $sql): bool
+    {
+        return true;
+    }
+
+    public function getValue($sql): mixed
+    {
+        return false;
+    }
+
+    public function executeS($sql): array
+    {
+        return [];
+    }
+}
+
 require_once dirname(__DIR__, 2) . '/hhcspheaders.php';
 require_once dirname(__DIR__, 2) . '/classes/CspViolation.php';

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -43,3 +43,11 @@ $_MODULE['<{hhcspheaders}prestashop>hhcspheaders_a228648d790fae815d682b56bebc616
 $_MODULE['<{hhcspheaders}prestashop>hhcspheaders_30ba208014f033c04370ee2283a65323'] = 'Impossible de supprimer le fichier de log';
 $_MODULE['<{hhcspheaders}prestashop>hhcspheaders_a6bb7e9882a2b76d9cf2b6228ea82b95'] = 'Pas de logs à afficher, le fichier %s n\'existe pas';
 $_MODULE['<{hhcspheaders}prestashop>hhcspheaders_c7ea238c84eee7251cd90ad408f2caaf'] = 'Voici le contenu du fichier %s , cliquer %s pour le supprimer';
+$_MODULE['<{hhcspheaders}prestashop>hhcspheaders_f376e155c5b9bdea52904a90267b9974'] = 'Violation marquée comme résolue';
+$_MODULE['<{hhcspheaders}prestashop>hhcspheaders_a3665f3567cb6e978e5d0186b1729927'] = 'Impossible de marquer la violation comme résolue';
+$_MODULE['<{hhcspheaders}prestashop>hhcspheaders_d0cbb79672d8112520e0bd50898469db'] = 'Toutes les violations ont été marquées comme résolues';
+$_MODULE['<{hhcspheaders}prestashop>hhcspheaders_b24ff65742a6982ce15d26e88622a01a'] = 'Impossible de marquer les violations comme résolues';
+$_MODULE['<{hhcspheaders}prestashop>hhcspheaders_c3f7c87b177c60cd8952e4623d42a08a'] = 'Êtes-vous sûr de vouloir marquer toutes les violations comme résolues ?';
+$_MODULE['<{hhcspheaders}prestashop>hhcspheaders_2e3df5299cfb1e9a4b9cb1849930df16'] = 'Tout marquer comme résolu';
+$_MODULE['<{hhcspheaders}prestashop>hhcspheaders_418c5509e2171d55b0aee5c2ea4442b5'] = 'Action';
+$_MODULE['<{hhcspheaders}prestashop>hhcspheaders_785e254f4f43227df02945c04559dbaf'] = 'Résoudre';


### PR DESCRIPTION
## Summary

- Add `markAsResolved()` method on `CspViolation` to mark a single violation as resolved
- Add `markAllAsResolved()` static method to mark all unresolved violations at once
- Add a **Resolve** button per row in the violations table
- Add a **Mark all as resolved** button above the table
- Handle both new actions in `postProcess()`

## Context

The `is_resolved` field existed in the database schema and was used in queries (`WHERE is_resolved = 0`) and in the delete cleanup (`WHERE is_resolved = 1`), but no code ever set it to `1`. This made the "Clear Resolved Violations" button permanently useless.

## Test plan

- [x] Trigger CSP violations and verify they appear in the table with `is_resolved = 0`
- [x] Click **Resolve** on a single row → row disappears from the table, `is_resolved = 1` in DB
- [x] Click **Mark all as resolved** → all rows disappear, all set to `is_resolved = 1` in DB
- [x] Click **Clear Resolved Violations** → rows with `is_resolved = 1` are deleted from DB

Closes #14