### PR TITLE
Release 0.6.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
+V 0.6.0 2026-05-18  :
+                       - Add PrestaShop 9 compatibility
+                       - #14 Fix is_resolved never updated for CSP violations
+                       - Add Docker dev environment
+                       - Add PHPUnit unit tests
+                       - Fix security vulnerabilities in dev dependencies (phpunit CVE-2026-24765, symfony/process CVE-2024-51736 & CVE-2026-24739)
 V 0.5.0 2025-11-02  :
                        - #9 Replace log file by database records
                        - #8 Manage referer policies

--- a/hhcspheaders.php
+++ b/hhcspheaders.php
@@ -66,9 +66,10 @@ class Hhcspheaders extends Module
     {
         $this->name = 'hhcspheaders';
         $this->tab = 'others';
-        $this->version = '0.5.0';
+        $this->version = '0.6.0';
         $this->author = 'hhennes';
         $this->bootstrap = true;
+        $this->ps_versions_compliancy = ['min' => '8.0.0', 'max' => '9.99.99.99'];
         parent::__construct();
 
         $this->displayName = $this->l('Hh csp headers');


### PR DESCRIPTION
## Changelog 0.6.0

- Add PrestaShop 9 compatibility (`ps_versions_compliancy` min: 8.0.0, max: 9.99.99.99)
- #14 Fix is_resolved never updated for CSP violations
- Add Docker dev environment
- Add PHPUnit unit tests
- Fix security vulnerabilities in dev dependencies (phpunit CVE-2026-24765, symfony/process CVE-2024-51736 & CVE-2026-24739)